### PR TITLE
Correctly update the movement speed according to the default values

### DIFF
--- a/src/de/tudarmstadt/informatik/fop/breakout/actions/StickMoveAction.java
+++ b/src/de/tudarmstadt/informatik/fop/breakout/actions/StickMoveAction.java
@@ -25,7 +25,7 @@ public class StickMoveAction implements Action {
 
     @Override
     public void update(GameContainer gameContainer, StateBasedGame stateBasedGame, int delta, Component component) {
-        Vector2f frameVelocity = STICK_SPEED.copy().scale(delta / 17F);
+        Vector2f frameVelocity = STICK_SPEED.copy().scale(delta);
         if (moveDirection == Direction.LEFT) {
             frameVelocity.scale(-1);
         }

--- a/src/de/tudarmstadt/informatik/fop/breakout/constants/GameParameters.java
+++ b/src/de/tudarmstadt/informatik/fop/breakout/constants/GameParameters.java
@@ -44,7 +44,7 @@ public interface GameParameters {
 
 	// Ball
 	public static final String BALL_ID = "ball";
-	public static final float INITIAL_BALL_SPEED = 3f; //default 0.3
+	public static final float INITIAL_BALL_SPEED = 0.3f;
 	public static final float SPEEDUP_VALUE = 0.0001f;
 	public static final String BALL_IMAGE = "/images/ball.png";
 

--- a/src/de/tudarmstadt/informatik/fop/breakout/controllers/BallController.java
+++ b/src/de/tudarmstadt/informatik/fop/breakout/controllers/BallController.java
@@ -44,7 +44,7 @@ public class BallController extends Component {
         BallModel ball = getOwnerEntity();
 
         Vector2f oldPosition = ball.getPosition();
-        Vector2f newPosition = oldPosition.add(ball.getVelocity().copy().scale(delta / 17F));
+        Vector2f newPosition = oldPosition.add(ball.getVelocity().copy().scale(delta));
         ball.setPosition(newPosition);
     }
 }


### PR DESCRIPTION
The given constant values inside the GameParameters class could be movement
per ms. This means we have to scale it according to our delta value.

The delta is set the time ()ms since the last tick/update. This means if a
computer cannot keep up with our target frame rate, the updates per one second
will be lower, but our delta value will be higher as normal.

Example:
0.3 * 10ms = 3 pixel
0.3 * 20ms = 6 pixel lower framerate per second, but more movement per second
   to have the same speed for our users

This would remove the need to have constant magic value of 17F. That might
differ for each user.